### PR TITLE
Enforce dependencies check at runtime

### DIFF
--- a/haproxy/haproxy_cmd/run.go
+++ b/haproxy/haproxy_cmd/run.go
@@ -128,17 +128,20 @@ func CheckEnvironment(dataplaneapiBin, haproxyBin string) error {
 		currVer, e := getVersion(path)
 		if e != nil {
 			err = e
+			return
 		}
 		res, e := compareVersion(currVer, minVer)
 		if e != nil {
 			err = e
+			return
 		}
 		if res < 0 {
 			err = fmt.Errorf("%s version must be > %s, but is: %s", path, minVer, currVer)
+			return
 		}
 	}
 	go ensureVersion(haproxyBin, "2.0")
-	go ensureVersion(dataplaneapiBin, "1.2")
+	go ensureVersion(dataplaneapiBin, "2.1")
 
 	wg.Wait()
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -78,12 +78,11 @@ func main() {
 	flag.Parse()
 	if versionFlag != nil && *versionFlag {
 		fmt.Printf("Version: %s ; BuildTime: %s ; GitHash: %s\n", Version, BuildTime, GitHash)
-		status := 0
-		if err := validateRequirements(*dataplaneBin, *haproxyBin); err != nil {
-			fmt.Printf("ERROR: dataplane API / HAProxy dependencies are not satisfied: %s\n", err)
-			status = 4
-		}
-		os.Exit(status)
+		os.Exit(0)
+	}
+	if err := validateRequirements(*dataplaneBin, *haproxyBin); err != nil {
+		fmt.Printf("ERROR: dataplane API / HAProxy dependencies are not satisfied: %s\n", err)
+		os.Exit(4)
 	}
 
 	ll, err := log.ParseLevel(*logLevel)


### PR DESCRIPTION
Currently the binaries version are only checked when called
with flag "version". Now enforce it so that it fails with explicit
error message in case of missing binary or incorrect version installed.