### PR TITLE
Fix build version in makefile

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -4,7 +4,7 @@ SOURCES := $(shell find . -name '*.go')
 all: test bin
 
 $(BIN): $(SOURCES)
-	go build -o haproxy-connect -ldflags "-X main.BuildTime=`date -u '+%Y-%m-%dT%H:%M:%SZ'` -X main.GitHash=`git rev-parse HEAD` -X main.Version=$${TRAVIS_TAG:-Dev}"
+	go build -o haproxy-connect -ldflags "-X main.BuildTime=`date -u '+%Y-%m-%dT%H:%M:%SZ'` -X main.GitHash=`git rev-parse HEAD` -X main.Version=`git describe --tags`"
 
 bin: $(BIN)
 


### PR DESCRIPTION
The build version was pulled from an env variable set by TRAVIS. Since commit aad5e02, we're now using a github action based on new tag to create a package.
Therefore, now we will use git tag instead of TRAVIS_TAG for the package build version.