### PR TITLE
remove nbproc option from haproxy configuration

### DIFF
--- a/haproxy/config.go
+++ b/haproxy/config.go
@@ -19,7 +19,6 @@ var defaultsHAProxyParams = HAProxyParams{
 	Globals: map[string]string{
 		"stats":                     "timeout 2m",
 		"tune.ssl.default-dh-param": "1024",
-		"nbproc":                    "1",
 		"nbthread":                  fmt.Sprint(runtime.GOMAXPROCS(0)),
 		"ulimit-n":                  "65536",
 		"maxconn":                   "32000",


### PR DESCRIPTION
Since HAProxy 2.5, nbproc option was removed.
As it is set to 1, which is the default value, and that nbthread option is set, as recommended by haproxy, remove the option so that it stays compatible for any haproxy version higher than 2.0.