### PR TITLE
Read token from environment variable if exists

### DIFF
--- a/main.go
+++ b/main.go
@@ -96,8 +96,14 @@ func main() {
 	consulConfig := &api.Config{
 		Address: *consulAddr,
 	}
+	env_token, env_token_exists := os.LookupEnv("CONNECT_CONSUL_TOKEN")
+	if env_token_exists {
+		consulConfig.Token = env_token
+		log.Info("Setting token from env variable CONNECT_CONSUL_TOKEN")
+	}
 	if token != nil {
 		consulConfig.Token = *token
+		log.Info("Setting token from command line")
 	}
 	consulClient, err := api.NewClient(consulConfig)
 	if err != nil {


### PR DESCRIPTION
In the current version, the consul token has be to specified as argument, which is not secure.
Now also read the token from environment variable CONNECT_CONSUL_TOKEN. Argument specification has precedence on environment variable.