### PR TITLE
Fix token check when read from command line

### DIFF
--- a/main.go
+++ b/main.go
@@ -101,7 +101,7 @@ func main() {
 		consulConfig.Token = env_token
 		log.Info("Setting token from env variable CONNECT_CONSUL_TOKEN")
 	}
-	if token != nil {
+	if *token != "" {
 		consulConfig.Token = *token
 		log.Info("Setting token from command line")
 	}


### PR DESCRIPTION
When token is not provided in command line, we incorrectly set this up to the default value, which is empty string.