### PR TITLE
Add new target in makefile for test

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,5 +1,6 @@
 BIN := haproxy-connect
 SOURCES := $(shell find . -name '*.go')
+GOLIST := $(shell go list ./... | egrep -v "/state$$|/haproxy-consul-connect$$")
 
 all: test bin
 
@@ -10,6 +11,10 @@ bin: $(BIN)
 
 test:
 	HAPROXY=/usr/sbin/haproxy DATAPLANEAPI=/usr/local/bin/dataplaneapi go test -timeout 600s ${gobuild_args} ./...
+
+test_wo_binaries:
+	go test $(GOLIST)
+
 check:
 	go fmt ./...
 	go vet ./...


### PR DESCRIPTION
Since some tests require to have a full envrionement, and therefore haproxy and dataplaneapi binaries, create a new target to run all tests that don't require those binaries.