### PR TITLE
Fix config test on nbthread

### DIFF
--- a/haproxy/config_test.go
+++ b/haproxy/config_test.go
@@ -2,6 +2,8 @@ package haproxy
 
 import (
 	"bytes"
+	"fmt"
+	"runtime"
 	"testing"
 
 	"github.com/haproxytech/haproxy-consul-connect/utils"
@@ -36,7 +38,7 @@ global
 	master-worker
 	stats socket stats_sock.sock mode 600 level admin expose-fd listeners
 	maxconn 32000
-	nbthread 12
+	nbthread ` + fmt.Sprint(runtime.GOMAXPROCS(0)) + `
 	stats timeout 2m
 	tune.ssl.default-dh-param 1024
 	ulimit-n 65536


### PR DESCRIPTION
nbthread is dynamically set using variable GOMAXPROCS. But this variable is system dependent, causing test to fail when GOMAXPROCS is different from 12.