### PR TITLE
Introduce a new option to add a response header

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Usage of ./haproxy-consul-connect:
     	Consul agent address (default "127.0.0.1:8500")
   -log-level string
     	Log level (default "INFO")
+  -response-hdr string
+      Header name for a response header added to each request to track if it went through successfully. The value of that header is 'true'
   -sidecar-for string
     	The consul service id to proxy
   -sidecar-for-tag string

--- a/haproxy/dataplane/http_request_rule.go
+++ b/haproxy/dataplane/http_request_rule.go
@@ -28,3 +28,25 @@ func (t *tnx) CreateHTTPRequestRule(parentType, parentName string, rule models.H
 	}
 	return t.client.makeReq(http.MethodPost, fmt.Sprintf("/v2/services/haproxy/configuration/http_request_rules?parent_type=%s&parent_name=%s&transaction_id=%s", parentType, parentName, t.txID), rule, nil)
 }
+
+func (c *Dataplane) HTTPResponseRules(parentType, parentName string) ([]models.HTTPResponseRule, error) {
+	type resT struct {
+		Data []models.HTTPResponseRule `json:"data"`
+	}
+
+	var res resT
+
+	err := c.makeReq(http.MethodGet, fmt.Sprintf("/v2/services/haproxy/configuration/http_response_rules?parent_type=%s&parent_name=%s", parentType, parentName), nil, &res)
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Data, nil
+}
+
+func (t *tnx) CreateHTTPResponseRule(parentType, parentName string, rule models.HTTPResponseRule) error {
+	if err := t.ensureTnx(); err != nil {
+		return err
+	}
+	return t.client.makeReq(http.MethodPost, fmt.Sprintf("/v2/services/haproxy/configuration/http_response_rules?parent_type=%s&parent_name=%s&transaction_id=%s", parentType, parentName, t.txID), rule, nil)
+}

--- a/haproxy/state.go
+++ b/haproxy/state.go
@@ -104,6 +104,7 @@ func (h *HAProxy) watch(sd *lib.Shutdown) error {
 			LogSocket:        h.haConfig.LogsSock,
 			SPOEConfigPath:   h.haConfig.SPOE,
 			SPOESocket:       h.haConfig.SPOESock,
+			ResponseHdrName:  h.opts.ResponseHdrName,
 		}, h.haConfig, currentState, currentConfig)
 		if err != nil {
 			log.Error(err)

--- a/haproxy/state/apply.go
+++ b/haproxy/state/apply.go
@@ -88,6 +88,11 @@ func applyFrontends(ha HAProxy, old, new []Frontend) error {
 				return err
 			}
 		}
+
+		for _, r := range newUp.HTTPResponseRules {
+			err = ha.CreateHTTPResponseRule("frontend", newUp.Frontend.Name, r)
+		}
+
 	}
 
 	return nil

--- a/haproxy/state/downstream.go
+++ b/haproxy/state/downstream.go
@@ -78,6 +78,17 @@ func generateDownstream(opts Options, certStore CertificateStore, cfg consul.Dow
 		}
 	}
 
+	// Connect name header
+	if opts.ResponseHdrName != "" && feMode == models.FrontendModeHTTP {
+		fmt.Printf("header setting downstream")
+		fe.HTTPResponseRules = append(fe.HTTPResponseRules, models.HTTPResponseRule{
+			Index:     int64p(0),
+			Type:      models.HTTPResponseRuleTypeSetHeader,
+			HdrName:   opts.ResponseHdrName,
+			HdrFormat: "true",
+		})
+	}
+
 	state.Frontends = append(state.Frontends, fe)
 
 	var forwardFor *models.Forwardfor

--- a/haproxy/state/state.go
+++ b/haproxy/state/state.go
@@ -12,11 +12,12 @@ type FrontendFilter struct {
 }
 
 type Frontend struct {
-	Frontend            models.Frontend
-	Bind                models.Bind
-	LogTarget           *models.LogTarget
-	FilterCompression   *FrontendFilter
-	FilterSpoe          *FrontendFilter
+	Frontend          models.Frontend
+	Bind              models.Bind
+	LogTarget         *models.LogTarget
+	FilterCompression *FrontendFilter
+	FilterSpoe        *FrontendFilter
+	HTTPResponseRules []models.HTTPResponseRule
 }
 
 type Backend struct {

--- a/haproxy/state/states.go
+++ b/haproxy/state/states.go
@@ -19,6 +19,7 @@ type Options struct {
 	LogSocket        string
 	SPOEConfigPath   string
 	SPOESocket       string
+	ResponseHdrName  string
 }
 
 type CertificateStore interface {
@@ -38,6 +39,7 @@ type HAProxy interface {
 	CreateTCPRequestRule(parentType, parentName string, rule models.TCPRequestRule) error
 	CreateLogTargets(parentType, parentName string, rule models.LogTarget) error
 	CreateHTTPRequestRule(parentType, parentName string, rule models.HTTPRequestRule) error
+	CreateHTTPResponseRule(parentType, parentName string, rule models.HTTPResponseRule) error
 }
 
 func Generate(opts Options, certStore CertificateStore, oldState State, cfg consul.Config) (State, error) {

--- a/haproxy/state/upstream.go
+++ b/haproxy/state/upstream.go
@@ -49,6 +49,17 @@ func generateUpstream(opts Options, certStore CertificateStore, cfg consul.Upstr
 		}
 	}
 
+	// Connect name header
+	if opts.ResponseHdrName != "" && feMode == models.FrontendModeHTTP {
+		fmt.Printf("header setting upstream")
+		fe.HTTPResponseRules = append(fe.HTTPResponseRules, models.HTTPResponseRule{
+			Index:     int64p(0),
+			Type:      models.HTTPResponseRuleTypeSetHeader,
+			HdrName:   opts.ResponseHdrName,
+			HdrFormat: "true",
+		})
+	}
+
 	newState.Frontends = append(newState.Frontends, fe)
 
 	be := Backend{

--- a/main.go
+++ b/main.go
@@ -74,6 +74,7 @@ func main() {
 	haproxyCfgBasePath := flag.String("haproxy-cfg-base-path", "/tmp", "Haproxy binary path")
 	statsListenAddr := flag.String("stats-addr", "", "Listen addr for stats server")
 	statsServiceRegister := flag.Bool("stats-service-register", false, "Register a consul service for connect stats")
+	responseHdrName := flag.String("response-hdr", "", "Header name for a response header added to each request to track if it went through successfully. The value of that header is 'true'")
 	enableIntentions := flag.Bool("enable-intentions", false, "Enable Connect intentions")
 	token := flag.String("token", "", "Consul ACL token")
 	flag.Parse()
@@ -160,6 +161,7 @@ func main() {
 		StatsRegisterService: *statsServiceRegister,
 		LogRequests:          ll == log.TraceLevel,
 		HAProxyParams:        haproxyParams,
+		ResponseHdrName:      *responseHdrName,
 	})
 	sd.Add(1)
 	go func() {

--- a/utils/options.go
+++ b/utils/options.go
@@ -35,4 +35,5 @@ type Options struct {
 	StatsRegisterService bool
 	LogRequests          bool
 	HAProxyParams        HAProxyParams
+	ResponseHdrName      string
 }


### PR DESCRIPTION
A new option is introduced to add a response header to each request going through successfully. The option is the name of the header,  with the value being set to 'true'.