### PR TITLE
Add option to control dataplane log level

### DIFF
--- a/haproxy/haproxy.go
+++ b/haproxy/haproxy.go
@@ -81,6 +81,7 @@ func (h *HAProxy) start(sd *lib.Shutdown) error {
 		DataplaneSock:           h.haConfig.DataplaneSock,
 		DataplaneUser:           h.haConfig.DataplaneUser,
 		DataplanePass:           h.haConfig.DataplanePass,
+		DataplaneLogLevel:       h.opts.DataplaneLogLevel,
 	})
 	if err != nil {
 		return err

--- a/haproxy/haproxy_cmd/run.go
+++ b/haproxy/haproxy_cmd/run.go
@@ -32,6 +32,7 @@ type Config struct {
 	DataplaneSock           string
 	DataplaneUser           string
 	DataplanePass           string
+	DataplaneLogLevel       string
 }
 
 func Start(sd *lib.Shutdown, cfg Config) (*dataplane.Dataplane, error) {
@@ -55,7 +56,7 @@ func Start(sd *lib.Shutdown, cfg Config) (*dataplane.Dataplane, error) {
 		"--userlist", "controller",
 		"--transaction-dir", cfg.DataplaneTransactionDir,
 		"--log-format", "JSON",
-		"--log-level", "info",
+		"--log-level", cfg.DataplaneLogLevel,
 	)
 	cleanupHAProxy := func() {
 		haCmd.Process.Signal(os.Kill)

--- a/haproxy/state/from_ha_test.go
+++ b/haproxy/state/from_ha_test.go
@@ -112,6 +112,7 @@ RHmDi0qnL6qrKfjTOnfHgQPCgxAy9knMIiDzBRg=
 		DataplaneSock:           cfgDir + "/dpsock",
 		DataplaneUser:           "usr",
 		DataplanePass:           "pass",
+		DataplaneLogLevel:       "info",
 	})
 	require.NoError(t, err)
 

--- a/main.go
+++ b/main.go
@@ -66,6 +66,7 @@ func main() {
 	flag.Var(&haproxyParamsFlag, "haproxy-param", "Global or defaults Haproxy config parameter to set in config. Can be specified multiple times. Must be of the form `defaults.name=value` or `global.name=value`")
 	versionFlag := flag.Bool("version", false, "Show version and exit")
 	logLevel := flag.String("log-level", "INFO", "Log level")
+	dataplaneLogLevel := flag.String("dataplane-log-level", "info", "Dataplane Log level")
 	consulAddr := flag.String("http-addr", "127.0.0.1:8500", "Consul agent address")
 	service := flag.String("sidecar-for", "", "The consul service id to proxy")
 	serviceTag := flag.String("sidecar-for-tag", "", "The consul service id to proxy")
@@ -154,6 +155,7 @@ func main() {
 	hap := haproxy.New(consulClient, watcher.C, utils.Options{
 		HAProxyBin:           *haproxyBin,
 		DataplaneBin:         *dataplaneBin,
+		DataplaneLogLevel:    *dataplaneLogLevel,
 		ConfigBaseDir:        *haproxyCfgBasePath,
 		EnableIntentions:     *enableIntentions,
 		StatsListenAddr:      *statsListenAddr,

--- a/utils/options.go
+++ b/utils/options.go
@@ -28,6 +28,7 @@ func (p HAProxyParams) With(other HAProxyParams) HAProxyParams {
 type Options struct {
 	HAProxyBin           string
 	DataplaneBin         string
+	DataplaneLogLevel    string
 	ConfigBaseDir        string
 	SPOEAddress          string
 	EnableIntentions     bool


### PR DESCRIPTION
This will allow to reduce verbose logs like
```
  level=info msg="dataplane: started handling request" method=GET remote=@ request=/v2/services/haproxy/stats/native
  level=info msg="dataplane: completed handling request" length=5.11kB status=200 took=3.485881e+06
```

By setting the dataplane log level to error at startup