### PR TITLE
Support passing haproxy options with same prefix

### DIFF
--- a/haproxy/config.go
+++ b/haproxy/config.go
@@ -17,15 +17,15 @@ import (
 )
 
 var defaultsHAProxyParams = utils.HAProxyParams{
-	Globals: map[string]string{
-		"stats":                     "timeout 2m",
-		"tune.ssl.default-dh-param": "1024",
-		"nbthread":                  fmt.Sprint(runtime.GOMAXPROCS(0)),
-		"ulimit-n":                  "65536",
-		"maxconn":                   "32000",
+	Globals: map[string][]string{
+		"stats":                     {"timeout 2m"},
+		"tune.ssl.default-dh-param": {"1024"},
+		"nbthread":                  {fmt.Sprint(runtime.GOMAXPROCS(0))},
+		"ulimit-n":                  {"65536"},
+		"maxconn":                   {"32000"},
 	},
-	Defaults: map[string]string{
-		"http-reuse": "always",
+	Defaults: map[string][]string{
+		"http-reuse": {"always"},
 	},
 }
 
@@ -33,13 +33,17 @@ const baseCfgTmpl = `
 global
 	master-worker
 	stats socket {{.SocketPath}} mode 600 level admin expose-fd listeners
-	{{- range $k, $v := .HAProxyParams.Globals}}
+	{{- range $k, $vs := .HAProxyParams.Globals}}
+	{{- range $v := $vs}}
 	{{$k}} {{$v}}
+	{{- end }}
 	{{- end }}
 
 defaults
-	{{- range $k, $v := .HAProxyParams.Defaults}}
+	{{- range $k, $vs := .HAProxyParams.Defaults}}
+	{{- range $v := $vs}}
 	{{$k}} {{$v}}
+	{{- end }}
 	{{- end }}
 	compression algo gzip
 	compression type text/css text/html text/javascript application/javascript text/plain text/xml application/json

--- a/utils/flags.go
+++ b/utils/flags.go
@@ -18,8 +18,8 @@ func (i *StringSliceFlag) Set(value string) error {
 
 func MakeHAProxyParams(flags StringSliceFlag) (HAProxyParams, error) {
 	params := HAProxyParams{
-		Defaults: map[string]string{},
-		Globals:  map[string]string{},
+		Defaults: map[string][]string{},
+		Globals:  map[string][]string{},
 	}
 
 	for _, flag := range flags {
@@ -33,7 +33,7 @@ func MakeHAProxyParams(flags StringSliceFlag) (HAProxyParams, error) {
 			return params, fmt.Errorf("bad haproxy-param flag %s, expected {type}.{name}={value}", flag)
 		}
 
-		var t map[string]string
+		var t map[string][]string
 		switch parts[0][:dot] {
 		case "defaults":
 			t = params.Defaults
@@ -43,7 +43,11 @@ func MakeHAProxyParams(flags StringSliceFlag) (HAProxyParams, error) {
 			return params, fmt.Errorf("bad haproxy-param flag %s, param type must be `defaults` or `global`", flag)
 		}
 
-		t[parts[0][dot+1:]] = parts[1]
+		_, ok := t[parts[0][dot+1:]]
+		if !ok  {
+			t[parts[0][dot+1:]] = []string{}
+		}
+		t[parts[0][dot+1:]] = append(t[parts[0][dot+1:]], parts[1])
 	}
 
 	return params, nil

--- a/utils/flags_test.go
+++ b/utils/flags_test.go
@@ -10,6 +10,7 @@ func TestMakeHAProxyParams(t *testing.T) {
 	flags := StringSliceFlag{
 		"defaults.test.with.dots=3",
 		"defaults.another=abdc",
+		"defaults.another=efgh",
 		"global.with.spaces=hey I have spaces",
 		"global.with.dots=hey.I.have.dots",
 	}
@@ -18,13 +19,13 @@ func TestMakeHAProxyParams(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, HAProxyParams{
-		Defaults: map[string]string{
-			"test.with.dots": "3",
-			"another":        "abdc",
+		Defaults: map[string][]string{
+			"test.with.dots": {"3"},
+			"another":        {"abdc", "efgh"},
 		},
-		Globals: map[string]string{
-			"with.spaces": "hey I have spaces",
-			"with.dots":   "hey.I.have.dots",
+		Globals: map[string][]string{
+			"with.spaces": {"hey I have spaces"},
+			"with.dots":   {"hey.I.have.dots"},
 		},
 	}, r)
 }

--- a/utils/options.go
+++ b/utils/options.go
@@ -1,14 +1,14 @@
 package utils
 
 type HAProxyParams struct {
-	Defaults map[string]string
-	Globals  map[string]string
+	Defaults map[string][]string
+	Globals  map[string][]string
 }
 
 func (p HAProxyParams) With(other HAProxyParams) HAProxyParams {
 	new := HAProxyParams{
-		Defaults: map[string]string{},
-		Globals:  map[string]string{},
+		Defaults: map[string][]string{},
+		Globals:  map[string][]string{},
 	}
 	for k, v := range p.Defaults {
 		new.Defaults[k] = v


### PR DESCRIPTION
This is to unlock the possibility to add multiple haproxy option that starts with the same name.
For example, following is now supported

`-haproxy-param defaults.option=accept-invalid-http-request -haproxy-param defaults.option=redispatch 1`

which allows to generate config

```
defaults
  option redispatch 1
  option accept-invalid-http-request
```

configuration totally supported by haproxy