### PR TITLE
haproxy_cmd: relax version check 

### DIFF
--- a/haproxy/haproxy_cmd/run_test.go
+++ b/haproxy/haproxy_cmd/run_test.go
@@ -17,6 +17,7 @@ func TestCompareVersion(t *testing.T) {
 		{status: 1, v1: "1.3", v2: "1.2"},
 		{status: 1, v1: "1.3.1", v2: "1.3"},
 		{status: 1, v1: "2.0.1", v2: "2.0"},
+		{status: 1, v1: "3.0", v2: "2.2.2"},
 		{status: 0, v1: "2.0", v2: "2.0"},
 		{status: 0, v1: "2.0.0", v2: "2.0"},
 		{status: 0, v1: "2.0", v2: "2.0.0"},
@@ -25,7 +26,6 @@ func TestCompareVersion(t *testing.T) {
 		{status: -1, v1: "2.0", v2: "2.0.1"},
 		{status: -1, v1: "2", v2: "2.0.1"},
 		{status: -1, v1: "2.0", v2: "2"},
-		{status: -1, v1: "3.0", v2: "2.2.2"},
 		{status: -1, v1: "2.2", v2: "3.0"},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
Check version is between a minimum and a maximum suppported version
instead of requiring a specific major version. This allows to support
more than a major version.